### PR TITLE
Add a builder-style generator for PermissionModel

### DIFF
--- a/app/src/main/java/com/fastaccess/permission/sample/SamplePagerActivity.java
+++ b/app/src/main/java/com/fastaccess/permission/sample/SamplePagerActivity.java
@@ -2,8 +2,6 @@ package com.fastaccess.permission.sample;
 
 import android.Manifest;
 import android.content.Context;
-import android.content.res.Resources;
-import android.graphics.Color;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.view.ViewPager;
@@ -11,6 +9,7 @@ import android.util.Log;
 
 import com.fastaccess.permission.base.activity.BasePermissionActivity;
 import com.fastaccess.permission.base.model.PermissionModel;
+import com.fastaccess.permission.base.model.PermissionModelBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -21,53 +20,54 @@ public class SamplePagerActivity extends BasePermissionActivity {
     @Override
     protected List<PermissionModel> permissions() {
         List<PermissionModel> permissions = new ArrayList<>();
-        PermissionModel model = getDefaultInstance();
-        model.setCanSkip(true);
-        model.setPermissionName(Manifest.permission.GET_ACCOUNTS);
-        model.setTitle("GET_ACCOUNTS");
-        model.setMessage("PermissionHelper supports all screens, try rotating your phone/tablet");
-        model.setExplanationMessage("We need this permission to customize your experience by " +
-                "auto completing your email address");
-        model.setFontType("my_font.ttf");
-        model.setLayoutColor(getResources().getColor(R.color.colorPrimary));
-        model.setImageResourceId(R.drawable.permission_three);
-        permissions.add(model);
-        model = getDefaultInstance();
-        model.setTitle("ACCESS_FINE_LOCATION");
-        model.setCanSkip(false);
-        model.setPermissionName(Manifest.permission.ACCESS_FINE_LOCATION);
-        model.setMessage("PermissionHelper also prevents your app getting crashed if the " +
-                "requested permission never exists in your AndroidManifest" +
-                ". Android DOES!");
-        model.setExplanationMessage("We need this permission to access to your location to" +
-                " find nearby restaurants and places you like!");
-        model.setFontType("my_font.ttf");
-        model.setLayoutColor(getResources().getColor(R.color.colorAccent));
-        model.setImageResourceId(R.drawable.permission_two);
-        permissions.add(model);
-        model = getDefaultInstance();
-        model.setCanSkip(true);
-        model.setTitle("WRITE_EXTERNAL_STORAGE");
-        model.setPermissionName(Manifest.permission.WRITE_EXTERNAL_STORAGE);
-        model.setMessage("PermissionHelper lets you customize all these stuff you are seeing!." +
-                " if you ever thought of anything that improves the library please" +
-                " suggest by filling up an issue in github https://github.com/k0shk0sh/PermissionHelper");
-        model.setExplanationMessage("We need this permission to save your captured images and videos to your SD-Card");
-        model.setFontType("my_font.ttf");
-        model.setLayoutColor(getResources().getColor(R.color.blue));
-        model.setImageResourceId(R.drawable.permission_one);
-        permissions.add(model);
-        model = getDefaultInstance();
-        model.setCanSkip(false); /*explanation only once will be called otherwise we will
+        permissions.add(PermissionModelBuilder.withContext(this)
+                .withCanSkip(true)
+                .withPermissionName(Manifest.permission.GET_ACCOUNTS)
+                .withTitle(R.string.title_get_accounts)
+                .withMessage(R.string.message_get_accounts)
+                .withExplanationMessage(R.string.explanation_message_get_accounts)
+                .withFontType("my_font.ttf")
+                .withLayoutColorRes(R.color.colorPrimary)
+                .withImageResourceId(R.drawable.permission_three)
+                .build());
+
+        permissions.add(PermissionModelBuilder.withContext(this)
+                .withTitle("ACCESS_FINE_LOCATION")
+                .withCanSkip(false)
+                .withPermissionName(Manifest.permission.ACCESS_FINE_LOCATION)
+                .withMessage("PermissionHelper also prevents your app getting crashed if the " +
+                        "requested permission never exists in your AndroidManifest" +
+                        ". Android DOES!")
+                .withExplanationMessage("We need this permission to access to your location to" +
+                        " find nearby restaurants and places you like!")
+                .withFontType("my_font.ttf")
+                .withLayoutColorRes(R.color.colorAccent)
+                .withImageResourceId(R.drawable.permission_two)
+                .build());
+
+        permissions.add(PermissionModelBuilder.withContext(this)
+                .withCanSkip(true)
+                .withTitle("WRITE_EXTERNAL_STORAGE")
+                .withPermissionName(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                .withMessage("PermissionHelper lets you customize all these stuff you are seeing!." +
+                        " if you ever thought of anything that improves the library please" +
+                        " suggest by filling up an issue in github https://github.com/k0shk0sh/PermissionHelper")
+                .withExplanationMessage("We need this permission to save your captured images and videos to your SD-Card")
+                .withFontType("my_font.ttf")
+                .withLayoutColorRes(R.color.blue)
+                .withImageResourceId(R.drawable.permission_one)
+                .build());
+
+        permissions.add(PermissionModelBuilder.withContext(this)
+                .withCanSkip(false) /*explanation only once will be called otherwise we will
                             run into infinite request if the user never grant the permission.*/
-        model.setTitle("SYSTEM_ALERT_WINDOW");
-        model.setPermissionName(Manifest.permission.SYSTEM_ALERT_WINDOW);
-        model.setMessage("PermissionHelper handles requesting SYSTEM_ALERT_WINDOW permission");
-        model.setExplanationMessage("We need this permission to make our videoPlayer overlay on your screen.");
-        model.setFontType("my_font.ttf");
-        model.setLayoutColor(getResources().getColor(R.color.colorPrimaryDark));
-        model.setImageResourceId(R.drawable.permission_two);
-        permissions.add(model);
+                .withTitle("SYSTEM_ALERT_WINDOW")
+                .withPermissionName(Manifest.permission.SYSTEM_ALERT_WINDOW)
+                .withMessage("PermissionHelper handles requesting SYSTEM_ALERT_WINDOW permission")
+                .withExplanationMessage("We need this permission to make our videoPlayer overlay on your screen.")
+                .withFontType("my_font.ttf")
+                .withLayoutColorRes(R.color.colorPrimaryDark)
+                .withImageResourceId(R.drawable.permission_two).build());
         return permissions;
     }
 
@@ -111,16 +111,5 @@ public class SamplePagerActivity extends BasePermissionActivity {
                 "        /** read {@link #permissionIsPermanentlyDenied(String)} **/\n" +
                 "    }");
 
-    }
-
-    private PermissionModel getDefaultInstance() {
-        Resources res = getResources();
-        PermissionModel model = new PermissionModel();
-        model.setTextColor(Color.WHITE);
-        model.setTextSize(res.getDimensionPixelSize(R.dimen.text_size));
-        model.setRequestIcon(R.drawable.ic_arrow_done);
-        model.setPreviousIcon(R.drawable.ic_arrow_left);
-        model.setNextIcon(R.drawable.ic_arrow_right);
-        return model;
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,6 @@
 <resources>
     <string name="app_name">AndroidPermissionHelper</string>
+    <string name="title_get_accounts">GET_ACCOUNTS</string>
+    <string name="message_get_accounts">PermissionHelper supports all screens, try rotating your phone/tablet</string>
+    <string name="explanation_message_get_accounts">We need this permission to customize your experience by auto completing your email address</string>
 </resources>

--- a/permission/src/main/java/com/fastaccess/permission/base/model/PermissionModelBuilder.java
+++ b/permission/src/main/java/com/fastaccess/permission/base/model/PermissionModelBuilder.java
@@ -1,6 +1,7 @@
 package com.fastaccess.permission.base.model;
 
 import android.content.Context;
+import android.content.res.Resources;
 import android.graphics.Color;
 import android.support.annotation.ColorInt;
 import android.support.annotation.ColorRes;
@@ -13,14 +14,14 @@ import com.fastaccess.permission.R;
 
 
 public class PermissionModelBuilder {
-    private final Context context;
+    private final Resources res;
     private final PermissionModel permissionModel;
 
     private PermissionModelBuilder(@NonNull Context context) {
-        this.context = context;
+        this.res = context.getResources();
         this.permissionModel = new PermissionModel(); // Generate sane default values
         withTextColor(Color.WHITE);
-        withTextSize(context.getResources().getDimensionPixelSize(R.dimen.text_size));
+        withTextSize(res.getDimensionPixelSize(R.dimen.text_size));
         withRequestIcon(R.drawable.ic_arrow_done);
         withPreviousIcon(R.drawable.ic_arrow_left);
         withNextIcon(R.drawable.ic_arrow_right);
@@ -51,7 +52,7 @@ public class PermissionModelBuilder {
     }
 
     public PermissionModelBuilder withLayoutColorRes(@ColorRes int layoutColor) {
-        this.permissionModel.setLayoutColor(context.getResources().getColor(layoutColor));
+        this.permissionModel.setLayoutColor(res.getColor(layoutColor));
         return this;
     }
 
@@ -62,7 +63,7 @@ public class PermissionModelBuilder {
     }
 
     public PermissionModelBuilder withTextColorRes(@ColorRes int textColor) {
-        this.permissionModel.setTextColor(context.getResources().getColor(textColor));
+        this.permissionModel.setTextColor(res.getColor(textColor));
         return this;
     }
 
@@ -78,7 +79,7 @@ public class PermissionModelBuilder {
     }
 
     public PermissionModelBuilder withExplanationMessage(@StringRes int explanationMessage) {
-        this.permissionModel.setExplanationMessage(context.getResources().getString(explanationMessage));
+        this.permissionModel.setExplanationMessage(res.getString(explanationMessage));
         return this;
     }
 
@@ -112,7 +113,7 @@ public class PermissionModelBuilder {
     }
 
     public PermissionModelBuilder withMessage(@StringRes int message) {
-        this.permissionModel.setMessage(context.getResources().getString(message));
+        this.permissionModel.setMessage(res.getString(message));
         return this;
     }
 
@@ -122,7 +123,7 @@ public class PermissionModelBuilder {
     }
 
     public PermissionModelBuilder withTitle(@StringRes int title) {
-        this.permissionModel.setTitle(context.getResources().getString(title));
+        this.permissionModel.setTitle(res.getString(title));
         return this;
     }
 

--- a/permission/src/main/java/com/fastaccess/permission/base/model/PermissionModelBuilder.java
+++ b/permission/src/main/java/com/fastaccess/permission/base/model/PermissionModelBuilder.java
@@ -1,0 +1,136 @@
+package com.fastaccess.permission.base.model;
+
+import android.content.Context;
+import android.graphics.Color;
+import android.support.annotation.ColorInt;
+import android.support.annotation.ColorRes;
+import android.support.annotation.DimenRes;
+import android.support.annotation.DrawableRes;
+import android.support.annotation.NonNull;
+import android.support.annotation.StringRes;
+
+import com.fastaccess.permission.R;
+
+
+public class PermissionModelBuilder {
+    private final Context context;
+    private final PermissionModel permissionModel;
+
+    private PermissionModelBuilder(@NonNull Context context) {
+        this.context = context;
+        this.permissionModel = new PermissionModel(); // Generate sane default values
+        withTextColor(Color.WHITE);
+        withTextSize(context.getResources().getDimensionPixelSize(R.dimen.text_size));
+        withRequestIcon(R.drawable.ic_arrow_done);
+        withPreviousIcon(R.drawable.ic_arrow_left);
+        withNextIcon(R.drawable.ic_arrow_right);
+    }
+
+    public static PermissionModelBuilder withContext(@NonNull Context context) {
+        return new PermissionModelBuilder(context);
+    }
+
+    public PermissionModel build() {
+        return permissionModel;
+    }
+
+    public PermissionModelBuilder withPermissionName(@NonNull String permissionName) {
+        this.permissionModel.setPermissionName(permissionName);
+        return this;
+    }
+
+    public PermissionModelBuilder withImageResourceId(@DrawableRes int imageResourceId) {
+        this.permissionModel.setImageResourceId(imageResourceId);
+        return this;
+    }
+
+
+    public PermissionModelBuilder withLayoutColor(@ColorInt int layoutColor) {
+        this.permissionModel.setLayoutColor(layoutColor);
+        return this;
+    }
+
+    public PermissionModelBuilder withLayoutColorRes(@ColorRes int layoutColor) {
+        this.permissionModel.setLayoutColor(context.getResources().getColor(layoutColor));
+        return this;
+    }
+
+
+    public PermissionModelBuilder withTextColor(@ColorInt int textColor) {
+        this.permissionModel.setTextColor(textColor);
+        return this;
+    }
+
+    public PermissionModelBuilder withTextColorRes(@ColorRes int textColor) {
+        this.permissionModel.setTextColor(context.getResources().getColor(textColor));
+        return this;
+    }
+
+
+    public PermissionModelBuilder withTextSize(@DimenRes int textSize) {
+        this.permissionModel.setTextSize(textSize);
+        return this;
+    }
+
+    public PermissionModelBuilder withExplanationMessage(@NonNull String explanationMessage) {
+        this.permissionModel.setExplanationMessage(explanationMessage);
+        return this;
+    }
+
+    public PermissionModelBuilder withExplanationMessage(@StringRes int explanationMessage) {
+        this.permissionModel.setExplanationMessage(context.getResources().getString(explanationMessage));
+        return this;
+    }
+
+    public PermissionModelBuilder withCanSkip(boolean canSkip) {
+        this.permissionModel.setCanSkip(canSkip);
+        return this;
+    }
+
+
+    public PermissionModelBuilder withRequestIcon(@DrawableRes int requestIcon) {
+        this.permissionModel.setRequestIcon(requestIcon);
+        return this;
+    }
+
+
+    public PermissionModelBuilder withPreviousIcon(@DrawableRes int previousIcon) {
+        this.permissionModel.setPreviousIcon(previousIcon);
+        return this;
+    }
+
+
+    public PermissionModelBuilder withNextIcon(@DrawableRes int nextIcon) {
+        this.permissionModel.setNextIcon(nextIcon);
+        return this;
+    }
+
+
+    public PermissionModelBuilder withMessage(@NonNull String message) {
+        this.permissionModel.setMessage(message);
+        return this;
+    }
+
+    public PermissionModelBuilder withMessage(@StringRes int message) {
+        this.permissionModel.setMessage(context.getResources().getString(message));
+        return this;
+    }
+
+    public PermissionModelBuilder withTitle(@NonNull String title) {
+        this.permissionModel.setTitle(title);
+        return this;
+    }
+
+    public PermissionModelBuilder withTitle(@StringRes int title) {
+        this.permissionModel.setTitle(context.getResources().getString(title));
+        return this;
+    }
+
+    /**
+     * @param fontType ex: (fonts/my_custom_text.ttf);
+     */
+    public PermissionModelBuilder withFontType(@NonNull String fontType) {
+        this.permissionModel.setFontType(fontType);
+        return this;
+    }
+}

--- a/permission/src/main/res/values/dimens.xml
+++ b/permission/src/main/res/values/dimens.xml
@@ -1,0 +1,3 @@
+<resources>
+    <dimen name="text_size">16sp</dimen>
+</resources>


### PR DESCRIPTION
This is a more fluent way to construct PermissionModel
For example, before :

```
List<PermissionModel> permissions = new ArrayList<>();
PermissionModel model = getDefaultInstance();
model.setCanSkip(true);
model.setPermissionName(Manifest.permission.GET_ACCOUNTS);
model.setTitle(this.getResources().getString(R.string.title_get_accounts));
model.setMessage(this.getResources().getString(R.string.message_get_accounts));
model.setExplanationMessage(this.getResources().getString(R.string.explanation_message_get_accounts));
model.setFontType("my_font.ttf");
model.setLayoutColorRes(this.getResources().getColor(R.color.colorPrimary));
model.setImageResourceId(R.drawable.permission_three);
permissions.add(model);
```

After:

```
List<PermissionModel> permissions = new ArrayList<>();
permissions.add(PermissionModelBuilder.withContext(this)
        .withCanSkip(true)
        .withPermissionName(Manifest.permission.GET_ACCOUNTS)
        .withTitle(R.string.title_get_accounts)
        .withMessage(R.string.message_get_accounts)
        .withExplanationMessage(R.string.explanation_message_get_accounts)
        .withFontType("my_font.ttf")
        .withLayoutColorRes(R.color.colorPrimary)
        .withImageResourceId(R.drawable.permission_three)
        .build());
```
